### PR TITLE
fix: crash when process name filter longer than 7

### DIFF
--- a/ntop.c
+++ b/ntop.c
@@ -1700,7 +1700,7 @@ int _tmain(int argc, TCHAR *argv[])
             TCHAR *Context;
             TCHAR *Token = _tcstok_s(argv[i], Delim, &Context);
             while(Token && NameFilterCount < MAX_NAMEPARTS) {
-              strcpy_s(NameFilterList[NameFilterCount++], sizeof(Token) < MAX_NAMEPARTSIZE ? sizeof(Token) : MAX_NAMEPARTSIZE, Token);
+              _tcsncpy_s(NameFilterList[NameFilterCount++], MAX_NAMEPARTSIZE+1, Token, MAX_NAMEPARTSIZE);
               Token = _tcstok_s(0, Delim, &Context);
             }
 


### PR DESCRIPTION
There are two issues in the codes related to the `process name filter` that result in a crash when the provided process name exceeds 7 characters in length:

1. The use of `sizeof(Token)` does not return the length of the string but instead gives the size of a `pointer to TCHAR`, which is always 8 bytes on the `amd64` platform.

2. The `strcpy_s` function crashes when the length of the `src` (the third argument) exceeds the `destsz` (the second argument), as observed in my tests.

This PR resolves the crash by replacing `strcpy_s` with `_tcsncpy_s`.

@4x3-64